### PR TITLE
feat: distributed queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+.idea
+cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ FetchContent_Declare(
   GraphStreamingCC
 
   GIT_REPOSITORY      https://github.com/GraphStreamingProject/GraphStreamingCC
-  GIT_TAG             main
+  GIT_TAG             badSketchSerialization
 
 )
 FetchContent_MakeAvailable(GraphStreamingCC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ target_link_libraries(distrib_tests PUBLIC DistribUpdateStreamingVerifyCC)
 
 add_executable(speed_expr
   experiment/cluster_speed_expr.cpp
+  tools/streaming/gz_specific/gz_nonsequential_streamer.cpp
 )
 add_dependencies(speed_expr DistribUpdateStreamingCC)
 target_link_libraries(speed_expr PUBLIC DistribUpdateStreamingCC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ FetchContent_Declare(
   GraphStreamingCC
 
   GIT_REPOSITORY      https://github.com/GraphStreamingProject/GraphStreamingCC
-  GIT_TAG             ostream
+  GIT_TAG             expose_sketch
 )
 FetchContent_MakeAvailable(GraphStreamingCC)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ FetchContent_Declare(
   GraphStreamingCC
 
   GIT_REPOSITORY      https://github.com/GraphStreamingProject/GraphStreamingCC
-  GIT_TAG             expose_sketch
+  GIT_TAG             main
 
 )
 FetchContent_MakeAvailable(GraphStreamingCC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,10 +112,16 @@ target_link_libraries(distrib_tests PUBLIC DistribUpdateStreamingVerifyCC)
 
 add_executable(speed_expr
   experiment/cluster_speed_expr.cpp
-  tools/streaming/gz_specific/gz_nonsequential_streamer.cpp
 )
 add_dependencies(speed_expr DistribUpdateStreamingCC)
 target_link_libraries(speed_expr PUBLIC DistribUpdateStreamingCC)
+
+add_executable(hashstream_expr
+  experiment/cluster_hashstream_expr.cpp
+  tools/streaming/gz_specific/gz_nonsequential_streamer.cpp
+)
+add_dependencies(hashstream_expr DistribUpdateStreamingCC)
+target_link_libraries(hashstream_expr PUBLIC DistribUpdateStreamingCC)
 
 #####################################################################
 #####################    Streaming utilities    #####################

--- a/experiment/cluster_hashstream_expr.cpp
+++ b/experiment/cluster_hashstream_expr.cpp
@@ -1,41 +1,45 @@
 #include <graph_distrib_update.h>
-#include <binary_graph_stream.h>
 #include <work_distributor.h>
 
 #include <string>
 #include <iostream>
+#include "../tools/streaming/gz_specific/gz_nonsequential_streamer.h"
 
 int main(int argc, char **argv) {
   GraphDistribUpdate::setup_cluster(argc, argv);
 
-  if (argc != 4) {
+  if (argc != 5) {
     std::cout << "Incorrect number of arguments. "
-                 "Expected 3 but got " << argc-1 << std::endl;
-    std::cout << "Arguments are: input_stream, num rounds to distribute, "
+                 "Expected 4 but got " << argc-1 << std::endl;
+    std::cout << "Arguments are: num_nodes, prime, num rounds to distribute, "
                  "output_file" << std::endl;
     exit(EXIT_FAILURE);
   }
-  std::string input  = argv[1];
-  int rounds_to_distr = atoi(argv[2]);
-  std::string output = argv[3];
+  node_id_t num_nodes = atoll(argv[1]);
+  node_id_t prime     = atoll(argv[2]);
+  int rounds_to_distr = atoi(argv[3]);
+  std::string output  = argv[4];
 
-  BinaryGraphStream stream(input, 32 * 1024);
+  double erp  = 0.5;
+  int rounds  = 2;
+  long seed1  = 437650290;
+  long seed2  = 1268991550;
+  long m      = 4e6;
+  long total  = m;
 
-  node_id_t num_nodes = stream.nodes();
-  long m              = stream.edges();
-  long total          = m;
+  GZNonsequentialStreamer stream(num_nodes, prime, erp, rounds, seed1, seed2);
   GraphDistribUpdate g{num_nodes};
 
   auto start = std::chrono::steady_clock::now();
 
   while (m--) {
-    g.update(stream.get_edge());
+    g.update(stream.next());
   }
 
   std::cout << "Starting CC" << std::endl;
   g.num_rounds_to_distribute(rounds_to_distr);
   uint64_t num_CC = g.spanning_forest_query().size();
-  
+
   std::chrono::duration<double> runtime = g.flush_end - start;
   std::chrono::duration<double> CC_time = g.cc_alg_end - g.cc_alg_start;
 
@@ -44,7 +48,7 @@ int main(int argc, char **argv) {
   std::cout << "Writing runtime stats to " << output << std::endl;
 
   // calculate the insertion rate and write to file
-  // insertion rate measured in stream updates 
+  // insertion rate measured in stream updates
   // (not in the two sketch updates we process per stream update)
   float ins_per_sec = (((float)(total)) / runtime.count());
   out << "Procesing " << total << " updates took " << runtime.count() << " seconds, " << ins_per_sec << " per second\n";

--- a/experiment/cluster_speed_expr.cpp
+++ b/experiment/cluster_speed_expr.cpp
@@ -9,15 +9,17 @@
 int main(int argc, char **argv) {
   GraphDistribUpdate::setup_cluster(argc, argv);
 
-  if (argc != 4) {
+  if (argc != 5) {
     std::cout << "Incorrect number of arguments. "
                  "Expected two but got " << argc-1 << std::endl;
-    std::cout << "Arguments are: num_nodes, prime, output_file" << std::endl;
+    std::cout << "Arguments are: num_nodes, prime, num rounds to distribute, "
+                 "output_file" << std::endl;
     exit(EXIT_FAILURE);
   }
   node_id_t num_nodes = atoll(argv[1]);
   node_id_t prime     = atoll(argv[2]);
-  std::string output  = argv[3];
+  int rounds_to_distr = atoi(argv[3]);
+  std::string output  = argv[4];
 
   double erp  = 0.5;
   int rounds  = 2;
@@ -36,6 +38,7 @@ int main(int argc, char **argv) {
   }
 
   std::cout << "Starting CC" << std::endl;
+  g.num_rounds_to_distribute(rounds_to_distr);
   uint64_t num_CC = g.spanning_forest_query().size();
   
   std::chrono::duration<double> runtime = g.flush_end - start;

--- a/include/distributed_worker.h
+++ b/include/distributed_worker.h
@@ -1,4 +1,5 @@
 #include <types.h>
+#include <string>
 
 // forward declaration
 class Supernode;
@@ -18,6 +19,8 @@ private:
 
   Supernode *delta_node; // the supernode object used to generate deltas
   int id; // id of the distributed worker
+  std::string serialized_ret;
+  int num_queries = INT_MAX;
 
   uint64_t num_updates = 0; // number of updates processed by this node
 

--- a/include/graph_distrib_update.h
+++ b/include/graph_distrib_update.h
@@ -7,7 +7,8 @@ private:
    * @param query  an array of supernode query results
    * @param reps   an array containing node indices for the representative of each supernode
    */
-  void sample_supernodes(std::pair<Edge, SampleSketchRet> *query, std::vector<node_id_t> &reps);
+  void sample_supernodes(std::pair<Edge, SampleSketchRet> *query,
+                         std::vector<node_id_t> &reps) override;
 
 public:
   // constructor

--- a/include/graph_distrib_update.h
+++ b/include/graph_distrib_update.h
@@ -2,6 +2,12 @@
 
 class GraphDistribUpdate : public Graph {
 private:
+  /**
+   * Overrides main graph sample code with distributed functionality.
+   * @param query  an array of supernode query results
+   * @param reps   an array containing node indices for the representative of each supernode
+   */
+  void sample_supernodes(std::pair<Edge, SampleSketchRet> *query, std::vector<node_id_t> &reps);
 
 public:
   // constructor

--- a/include/graph_distrib_update.h
+++ b/include/graph_distrib_update.h
@@ -10,6 +10,9 @@ private:
   void sample_supernodes(std::pair<Edge, SampleSketchRet> *query,
                          std::vector<node_id_t> &reps) override;
 
+  int _boruvka_round = 0;
+  int _rounds_to_distribute = INT_MAX;
+
 public:
   // constructor
   GraphDistribUpdate(node_id_t num_nodes);
@@ -21,6 +24,9 @@ public:
   Supernode *get_supernode(node_id_t src) const { return supernodes[src]; }
 
   std::vector<std::set<node_id_t>> spanning_forest_query(bool cont = false);
+
+  // set the number of rounds of boruvka queries to distribute
+  void num_rounds_to_distribute(int rounds) { _rounds_to_distribute = rounds; }
 
   /*
    * This function must be called at the beginning of the program

--- a/include/worker_cluster.h
+++ b/include/worker_cluster.h
@@ -123,6 +123,7 @@ public:
   static bool is_active() { return active; }
 
   static int get_num_workers() { return num_workers; }
+  static int get_max_msg_size() { return max_msg_size; }
 
   static constexpr size_t num_batches = 16; // the number of Supernodes updated by each batch_msg
 

--- a/include/worker_cluster.h
+++ b/include/worker_cluster.h
@@ -125,7 +125,8 @@ public:
   static int get_num_workers() { return num_workers; }
   static int get_max_msg_size() { return max_msg_size; }
 
-  static constexpr size_t num_batches = 512; // the number of Supernodes updated by each batch_msg
+  static constexpr size_t num_batches = 16; // the number of Supernodes
+  // updated by each batch_msg
 
 };
 

--- a/include/worker_cluster.h
+++ b/include/worker_cluster.h
@@ -125,7 +125,7 @@ public:
   static int get_num_workers() { return num_workers; }
   static int get_max_msg_size() { return max_msg_size; }
 
-  static constexpr size_t num_batches = 16; // the number of Supernodes updated by each batch_msg
+  static constexpr size_t num_batches = 512; // the number of Supernodes updated by each batch_msg
 
 };
 

--- a/include/worker_cluster.h
+++ b/include/worker_cluster.h
@@ -29,6 +29,7 @@ private:
   static uint64_t seed;
   static int max_msg_size;
   static bool active;
+  static char* msg_buffer;
 
   /*
    * DistributedWorker: call this function to recieve messages

--- a/include/worker_cluster.h
+++ b/include/worker_cluster.h
@@ -89,6 +89,11 @@ public:
    */
   static node_sketch_pairs send_batches_recv_deltas(int wid, const std::vector<data_ret_t> &batches);
 
+
+  static std::vector<std::pair<Edge, SampleSketchRet>>
+  send_sketches_recv_queries(int wid,
+                             const std::vector<Supernode *> &supernode_ptrs);
+
   /*
    * Return a supernode delta to the main node from the DistribUpdateWorker
    * @param delta_msg   A string containing the serialized deltas
@@ -101,7 +106,14 @@ public:
    */
   static void send_upds_processed(uint64_t num_updates);
 
+  static void serialize_samples(std::vector<std::pair<Edge, SampleSketchRet>>
+                          &samples, std::stringstream &serial_str);
+
+  static void return_samples(const std::string &sample_msg);
+
   static bool is_active() { return active; }
+
+  static int get_num_workers() { return num_workers; }
 };
 
 class BadMessageException : public std::exception {

--- a/src/graph_distrib_update.cpp
+++ b/src/graph_distrib_update.cpp
@@ -77,7 +77,7 @@ inline void GraphDistribUpdate::sample_supernodes(std::pair<Edge,
 
   std::cout << "Mini-batch size: " << batches_per_msg << "\n";
   std::cout << "Samples per worker: " << samples_per_worker << "\n";
-  
+
 #pragma omp parallel for num_threads(WorkerCluster::get_num_workers()) default(none) shared(reps, samples_per_worker, batches_per_msg, query, except, err)
   for (int wid = 0; wid < WorkerCluster::get_num_workers(); ++wid) {
     // wrap in a try/catch because exiting through exception is undefined behavior in OMP

--- a/src/graph_distrib_update.cpp
+++ b/src/graph_distrib_update.cpp
@@ -65,7 +65,7 @@ inline void GraphDistribUpdate::sample_supernodes(std::pair<Edge,
   // TODO: change out stopgap for actual fix
   uint64_t sketch_size = supernodes[0]->get_sketch_size() - sizeof
         (Sketch) + 1; // count only the data buffers
-  node_id_t num_safe_sketches = (WorkerCluster::max_msg_size - sizeof
+  node_id_t num_safe_sketches = (WorkerCluster::get_max_msg_size() - sizeof
         (sketch_size))/ (sketch_size + sizeof(uint64_t));
   node_id_t batches_per_msg = std::min(samples_per_worker, num_safe_sketches);
 

--- a/src/graph_distrib_update.cpp
+++ b/src/graph_distrib_update.cpp
@@ -41,6 +41,7 @@ void GraphDistribUpdate::teardown_cluster() {
 
 // Construct a GraphDistribUpdate by first constructing a Graph
 GraphDistribUpdate::GraphDistribUpdate(node_id_t num_nodes) : Graph(num_nodes) {
+
   // TODO: figure out a better solution than this.
   GraphWorker::stop_workers(); // shutdown the graph workers because we aren't using them
   WorkDistributor::start_workers(this, gts); // start threads and distributed cluster
@@ -55,7 +56,6 @@ GraphDistribUpdate::~GraphDistribUpdate() {
 inline void GraphDistribUpdate::sample_supernodes(std::pair<Edge,
                                                  SampleSketchRet> *query,
                                                  std::vector<node_id_t> &reps) {
-  std::cout << "Distributed sample used" << std::endl;
   bool except = false;
   std::exception_ptr err;
 

--- a/src/graph_distrib_update.cpp
+++ b/src/graph_distrib_update.cpp
@@ -48,6 +48,61 @@ GraphDistribUpdate::~GraphDistribUpdate() {
   std::cout << "Total updates processed by cluster since last init = " << updates << std::endl;
 }
 
+inline void GraphDistribUpdate::sample_supernodes(std::pair<Edge,
+                                                 SampleSketchRet> *query,
+                                                 std::vector<node_id_t> &reps) {
+  std::cout << "Distributed sample used" << std::endl;
+  bool except = false;
+  std::exception_ptr err;
+
+  node_id_t samples_per_worker = reps.size() / WorkerCluster::get_num_workers();
+  if (samples_per_worker * WorkerCluster::get_num_workers() < reps.size())
+    ++samples_per_worker;
+  // TODO: change out stopgap for actual fix
+  node_id_t batches_per_msg = std::min(samples_per_worker, (node_id_t)
+          double_to_ull(256u*std::log(num_nodes)));
+
+#pragma omp parallel for default(none) shared(reps, samples_per_worker, batches_per_msg, query, except, err)
+  for (int wid = 0; wid < WorkerCluster::get_num_workers(); ++wid) {
+    // wrap in a try/catch because exiting through exception is undefined behavior in OMP
+    try {
+      node_id_t samples_left = (wid == WorkerCluster::get_num_workers() - 1) ?
+                               reps.size() -
+                               (WorkerCluster::get_num_workers() - 1) *
+                               samples_per_worker :
+                               samples_per_worker;
+
+      // send in mini-batches
+      auto start_idx = samples_per_worker * wid;
+      auto end_idx = start_idx + samples_left;
+      for (node_id_t idx = start_idx; idx < end_idx;) {
+        auto num_to_send = std::min(end_idx - idx, batches_per_msg);
+        std::vector<Supernode *> supernode_ptrs(num_to_send);
+        for (node_id_t j = 0; j < num_to_send; ++j) {
+          supernode_ptrs[j] = supernodes[reps[idx + j]];
+        }
+        auto recvd_samples = WorkerCluster::send_sketches_recv_queries(wid + 1,
+                                                                       supernode_ptrs);
+        for (node_id_t j = 0; j < num_to_send; ++j) {
+          query[reps[idx + j]] = recvd_samples[j];
+        }
+        // manually increment all pointers of sampled supernodes by 1
+        for (auto supernode: supernode_ptrs) {
+          supernode->incr_idx();
+        }
+
+        idx += num_to_send;
+      }
+    } catch (...) {
+      except = true;
+      err = std::current_exception();
+    }
+  }
+  // Did one of our threads produce an exception?
+  if (except) std::rethrow_exception(err);
+}
+
+
 std::vector<std::set<node_id_t>> GraphDistribUpdate::spanning_forest_query(bool cont) {
   flush_start = std::chrono::steady_clock::now();
   gts->force_flush(); // flush everything in buffering system to make final updates

--- a/src/worker_cluster.cpp
+++ b/src/worker_cluster.cpp
@@ -115,7 +115,7 @@ std::vector<std::pair<Edge, SampleSketchRet>> WorkerCluster::send_sketches_recv_
   for (size_t i = 0; i < supernode_ptrs.size(); ++i) {
     const auto supernode = supernode_ptrs[i];
     if (supernode->out_of_queries()) throw OutOfQueriesException();
-    auto sketch = supernode->get_sketch(supernode->curr_idx());
+    auto sketch = supernode->get_const_sketch(supernode->curr_idx());
     uint64_t sketch_seed = sketch->get_seed();
     *((uint64_t*) (message + sizeof(sketch_size) +
                         (sketch_size + sizeof(sketch_seed))*i)) = sketch_seed;

--- a/src/worker_cluster.cpp
+++ b/src/worker_cluster.cpp
@@ -4,12 +4,14 @@
 #include <iostream>
 #include <mpi.h>
 #include <iomanip>
+#include <cstring>
 
 node_id_t WorkerCluster::num_nodes;
 int WorkerCluster::num_workers;
 uint64_t WorkerCluster::seed;
 int WorkerCluster::max_msg_size;
 bool WorkerCluster::active = false;
+char* WorkerCluster::msg_buffer;
 
 int WorkerCluster::start_cluster(node_id_t n_nodes, uint64_t _seed, int batch_size) {
   num_nodes = n_nodes;
@@ -19,6 +21,8 @@ int WorkerCluster::start_cluster(node_id_t n_nodes, uint64_t _seed, int batch_si
 
   MPI_Comm_size(MPI_COMM_WORLD, &num_workers);
   num_workers--; // don't count the main node
+
+  msg_buffer = static_cast<char *>(malloc(num_workers * max_msg_size));
 
   std::cout << "Number of workers is " << num_workers << ". Initializing!" << std::endl;
   for (int i = 0; i < num_workers; i++) {
@@ -108,25 +112,15 @@ std::vector<std::pair<Edge, SampleSketchRet>> WorkerCluster::send_sketches_recv_
   auto serial_begin = std::chrono::system_clock::now();
   // TODO: but we are going to run out of space if we have more than ~256*logV
   //  supernodes
-  char *message = new char[max_msg_size];
-  uint64_t sketch_size = supernode_ptrs[0]->get_sketch_size() - sizeof
-        (Sketch) + 1; // count only the data buffers
-  node_id_t msg_bytes = supernode_ptrs.size() * (sketch_size + sizeof
-        (uint64_t)) + sizeof (sketch_size);
+  char *message = msg_buffer + (wid-1)*max_msg_size;
+  int msg_bytes = supernode_ptrs.size() * Sketch::sketchSizeof();
 
-  *((uint64_t*) message) = sketch_size;
-  std::stringstream binary_stream;
   for (size_t i = 0; i < supernode_ptrs.size(); ++i) {
     const auto supernode = supernode_ptrs[i];
     if (supernode->out_of_queries()) throw OutOfQueriesException();
     auto sketch = supernode->get_const_sketch(supernode->curr_idx());
-    uint64_t sketch_seed = sketch->get_seed();
-    *((uint64_t*) (message + sizeof(sketch_size) +
-                        (sketch_size + sizeof(sketch_seed))*i)) = sketch_seed;
-    sketch->write_binary(binary_stream);
-    binary_stream.read(message + sizeof(sketch_size) +
-                        (sketch_size + sizeof(sketch_seed))*i + sizeof(sketch_seed),
-                        sketch_size);
+    std::memcpy(message + i*Sketch::sketchSizeof(), (char*) sketch,
+           Sketch::sketchSizeof());
   }
 
   auto send_begin = std::chrono::system_clock::now();
@@ -136,14 +130,12 @@ std::vector<std::pair<Edge, SampleSketchRet>> WorkerCluster::send_sketches_recv_
 
   auto send_end = std::chrono::system_clock::now();
 
-  delete[] message; // TODO: would be more efficient to reuse this memory
-
   // Wait for deltas to be returned
   int message_size = 0;
   MPI_Status status;
   MPI_Probe(wid, 0, MPI_COMM_WORLD, &status); // wait for a message from worker wid
   MPI_Get_count(&status, MPI_CHAR, &message_size);
-  char *msg_data = new char[message_size];
+  char *msg_data = msg_buffer + (wid-1)*max_msg_size;
   MPI_Recv(msg_data, message_size, MPI_CHAR, wid, 0, MPI_COMM_WORLD, &status);
 
   auto recv_end = std::chrono::system_clock::now();
@@ -154,12 +146,10 @@ std::vector<std::pair<Edge, SampleSketchRet>> WorkerCluster::send_sketches_recv_
     msg_stream.read((char*) &retval[i], sizeof(retval[i]));
   }
 
-  delete[] msg_data; // TODO: would be more efficient to reuse this memory
-
   auto deserial_end = std::chrono::system_clock::now();
 
   // print timestamps
-  long disp = 1649194000;
+  long disp = 1649215000;
   if (wid == 2) {
     std::cout << std::setprecision(20);
     std::cout << wid << "\t" << 0 << "\t" <<


### PR DESCRIPTION
Push queries and required sketches to workers to process.
TODO: allow more than 256*logV sketches to be passed in 1 message to a distributed worker.